### PR TITLE
UX para principiantes: constructor visual de filtros, estados vacíos y Bypass dentro de Scope (v1.0.1 Asahi)

### DIFF
--- a/frontend/App.compiled.js
+++ b/frontend/App.compiled.js
@@ -163,6 +163,7 @@ class ErrorBoundary extends React.Component {
 function Blackwire() {
   // Estado principal
   const [tab, setTab] = useState('projects');
+  const [scopeSubTab, setScopeSubTab] = useState('scope');
 
   // Request UI state (requests list in hook)
   const [selReq, setSelReq] = useState(null);
@@ -2496,6 +2497,19 @@ function Blackwire() {
 .flt-tog{padding:3px 8px;background:var(--bg2);border:1px solid var(--brd);border-radius:4px;font-size:10px;cursor:pointer;user-select:none}.flt-tog.act{background:var(--blue);border-color:var(--blue)}
 .flt-preset-wrap{position:static}
 .flt-preset-dd{position:absolute;top:100%;left:8px;right:8px;margin-top:4px;background:var(--bg2);border:1px solid var(--brd);border-radius:6px;z-index:200;box-shadow:0 8px 24px rgba(0,0,0,.4);max-height:320px;overflow-y:auto}
+.flt-builder-wrap{position:static}
+.flt-builder-dd{position:absolute;top:100%;left:8px;right:8px;margin-top:4px;background:var(--bg2);border:1px solid var(--brd);border-radius:6px;z-index:200;box-shadow:0 8px 24px rgba(0,0,0,.4);max-height:70vh;overflow-y:auto;padding:10px}
+.flt-builder-hd{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px;font-size:11px;font-weight:600;color:var(--txt2)}
+.flt-builder-hd .sel{font-size:11px;padding:3px 6px}
+.flt-builder-row{display:flex;align-items:center;gap:6px;margin-bottom:6px}
+.flt-builder-row .sel{font-size:11px;padding:4px 6px;flex:1;min-width:0}
+.flt-builder-row .inp{font-size:11px;padding:4px 6px;flex:1;min-width:0}
+.flt-builder-del{padding:2px 8px!important;flex-shrink:0}
+.flt-builder-add{margin:2px 0 10px}
+.flt-builder-preview{background:var(--bg);border:1px solid var(--brd);border-radius:4px;padding:8px;margin-bottom:10px}
+.flt-builder-preview-lbl{display:block;font-size:9px;text-transform:uppercase;letter-spacing:.5px;color:var(--txt3);margin-bottom:4px}
+.flt-builder-preview code{font-family:var(--font-mono);font-size:11px;color:var(--cyan);word-break:break-all}
+.flt-builder-acts{display:flex;justify-content:flex-end;gap:8px}
 .flt-preset-save{display:flex;gap:4px;padding:8px;border-bottom:1px solid var(--brd)}.flt-preset-save .flt-in{flex:1}
 .flt-preset-empty{padding:12px;text-align:center;color:var(--txt3);font-size:11px}
 .flt-preset-group-label{padding:6px 8px 2px;font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;color:var(--txt3)}
@@ -2507,7 +2521,10 @@ function Blackwire() {
 .pagination-info{font-size:11px;color:var(--txt2);white-space:nowrap}
 .pagination-size{background:var(--bg3);color:var(--txt);border:1px solid var(--brd);border-radius:4px;padding:3px 6px;font-size:11px;outline:none;cursor:pointer;margin-left:auto}
 .pagination-size:focus{border-color:var(--blue)}.pagination-size option{background:var(--bg2);color:var(--txt)}
-.empty{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;color:var(--txt3);font-size:13px;gap:6px}.empty-i{font-size:40px;opacity:.3}
+.empty{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;color:var(--txt3);font-size:13px;gap:6px;text-align:center;padding:20px}.empty-i{font-size:40px;opacity:.3}
+.empty span{color:var(--txt2);font-weight:500}
+.empty .empty-hint{max-width:340px;font-size:11px;font-weight:400;color:var(--txt3);line-height:1.5}
+.empty .empty-hint b{color:var(--txt2)}.empty .empty-hint code{font-family:var(--font-mono);font-size:10px;background:var(--bg3);padding:1px 4px;border-radius:3px;color:var(--cyan)}
 .acts{display:flex;gap:6px}
 .prj-pnl{padding:24px;max-width:800px;margin:0 auto;width:100%;height:100%;overflow-y:auto}.prj-hdr{display:flex;justify-content:space-between;align-items:center;margin-bottom:20px}.prj-hdr h2{font-size:18px}
 .new-prj{background:var(--bg2);padding:16px;border-radius:8px;margin-bottom:16px;display:flex;flex-direction:column;gap:10px}
@@ -2798,7 +2815,6 @@ function Blackwire() {
             , React.createElement('div', { className: 'tab' + (tab === 'chepy' ? ' act' : ''), onClick: () => setTab('chepy'),}, "Cipher")
             , React.createElement('div', { className: 'tab' + (tab === 'compare' ? ' act' : ''), onClick: () => setTab('compare'),}, "Compare")
             , React.createElement('div', { className: 'tab' + (tab === 'sensitive' ? ' act' : ''), onClick: () => setTab('sensitive'),}, "Sensitive")
-            , React.createElement('div', { className: 'tab' + (tab === 'bypass' ? ' act' : ''), onClick: () => { setTab('bypass'); bypass.loadRules(); bypass.loadPresets(); bypass.loadStatus(); },}, "Bypass")
             , React.createElement('div', { className: 'tab' + (tab === 'extensions' ? ' act' : ''), onClick: () => setTab('extensions'),}, "Extensions")
             , React.createElement('div', { className: 'tab' + (tab === 'console' ? ' act' : ''), onClick: () => setTab('console'),}, "Console"
 
@@ -2823,7 +2839,19 @@ function Blackwire() {
 
         , tab === 'intercept' && curPrj && React.createElement(InterceptPanel, __appCtx)
 
-        , tab === 'scope' && curPrj && React.createElement(ScopePanel, __appCtx)
+        , tab === 'scope' && curPrj && (
+          React.createElement('div', { className: "hist-wrap",}
+            , React.createElement('div', { className: "hist-sub-tabs",}
+              , React.createElement('div', { className: 'hist-sub-tab' + (scopeSubTab === 'scope' ? ' act' : ''), onClick: () => setScopeSubTab('scope'),}, "Scope")
+              , React.createElement('div', { className: 'hist-sub-tab' + (scopeSubTab === 'bypass' ? ' act' : ''), onClick: () => { setScopeSubTab('bypass'); bypass.loadRules(); bypass.loadPresets(); bypass.loadStatus(); },}, "Proxy Bypass" )
+            )
+            , React.createElement('div', { style: { flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column' },}
+              , scopeSubTab === 'scope'
+                ? React.createElement(ScopePanel, __appCtx)
+                : React.createElement(BypassManager, { toast: hookToast, bypass: bypass })
+            )
+          )
+        )
 
         , tab === 'repeater' && curPrj && React.createElement(RepeaterPanel, __appCtx)
 
@@ -2837,8 +2865,6 @@ function Blackwire() {
         , tab === 'chepy' && curPrj && React.createElement(ChepyPanel, __appCtx)
 
         , tab === 'sensitive' && curPrj && React.createElement(SensitivePanel, __appCtx)
-
-        , tab === 'bypass' && curPrj && React.createElement(BypassManager, { toast: hookToast, bypass: bypass })
 
         , tab === 'intruder' && curPrj && React.createElement(IntruderPanel, __appCtx)
 

--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -163,6 +163,7 @@ class ErrorBoundary extends React.Component {
 function Blackwire() {
   // Estado principal
   const [tab, setTab] = useState('projects');
+  const [scopeSubTab, setScopeSubTab] = useState('scope');
 
   // Request UI state (requests list in hook)
   const [selReq, setSelReq] = useState(null);
@@ -2496,6 +2497,19 @@ function Blackwire() {
 .flt-tog{padding:3px 8px;background:var(--bg2);border:1px solid var(--brd);border-radius:4px;font-size:10px;cursor:pointer;user-select:none}.flt-tog.act{background:var(--blue);border-color:var(--blue)}
 .flt-preset-wrap{position:static}
 .flt-preset-dd{position:absolute;top:100%;left:8px;right:8px;margin-top:4px;background:var(--bg2);border:1px solid var(--brd);border-radius:6px;z-index:200;box-shadow:0 8px 24px rgba(0,0,0,.4);max-height:320px;overflow-y:auto}
+.flt-builder-wrap{position:static}
+.flt-builder-dd{position:absolute;top:100%;left:8px;right:8px;margin-top:4px;background:var(--bg2);border:1px solid var(--brd);border-radius:6px;z-index:200;box-shadow:0 8px 24px rgba(0,0,0,.4);max-height:70vh;overflow-y:auto;padding:10px}
+.flt-builder-hd{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px;font-size:11px;font-weight:600;color:var(--txt2)}
+.flt-builder-hd .sel{font-size:11px;padding:3px 6px}
+.flt-builder-row{display:flex;align-items:center;gap:6px;margin-bottom:6px}
+.flt-builder-row .sel{font-size:11px;padding:4px 6px;flex:1;min-width:0}
+.flt-builder-row .inp{font-size:11px;padding:4px 6px;flex:1;min-width:0}
+.flt-builder-del{padding:2px 8px!important;flex-shrink:0}
+.flt-builder-add{margin:2px 0 10px}
+.flt-builder-preview{background:var(--bg);border:1px solid var(--brd);border-radius:4px;padding:8px;margin-bottom:10px}
+.flt-builder-preview-lbl{display:block;font-size:9px;text-transform:uppercase;letter-spacing:.5px;color:var(--txt3);margin-bottom:4px}
+.flt-builder-preview code{font-family:var(--font-mono);font-size:11px;color:var(--cyan);word-break:break-all}
+.flt-builder-acts{display:flex;justify-content:flex-end;gap:8px}
 .flt-preset-save{display:flex;gap:4px;padding:8px;border-bottom:1px solid var(--brd)}.flt-preset-save .flt-in{flex:1}
 .flt-preset-empty{padding:12px;text-align:center;color:var(--txt3);font-size:11px}
 .flt-preset-group-label{padding:6px 8px 2px;font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;color:var(--txt3)}
@@ -2507,7 +2521,10 @@ function Blackwire() {
 .pagination-info{font-size:11px;color:var(--txt2);white-space:nowrap}
 .pagination-size{background:var(--bg3);color:var(--txt);border:1px solid var(--brd);border-radius:4px;padding:3px 6px;font-size:11px;outline:none;cursor:pointer;margin-left:auto}
 .pagination-size:focus{border-color:var(--blue)}.pagination-size option{background:var(--bg2);color:var(--txt)}
-.empty{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;color:var(--txt3);font-size:13px;gap:6px}.empty-i{font-size:40px;opacity:.3}
+.empty{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;color:var(--txt3);font-size:13px;gap:6px;text-align:center;padding:20px}.empty-i{font-size:40px;opacity:.3}
+.empty span{color:var(--txt2);font-weight:500}
+.empty .empty-hint{max-width:340px;font-size:11px;font-weight:400;color:var(--txt3);line-height:1.5}
+.empty .empty-hint b{color:var(--txt2)}.empty .empty-hint code{font-family:var(--font-mono);font-size:10px;background:var(--bg3);padding:1px 4px;border-radius:3px;color:var(--cyan)}
 .acts{display:flex;gap:6px}
 .prj-pnl{padding:24px;max-width:800px;margin:0 auto;width:100%;height:100%;overflow-y:auto}.prj-hdr{display:flex;justify-content:space-between;align-items:center;margin-bottom:20px}.prj-hdr h2{font-size:18px}
 .new-prj{background:var(--bg2);padding:16px;border-radius:8px;margin-bottom:16px;display:flex;flex-direction:column;gap:10px}
@@ -2798,7 +2815,6 @@ function Blackwire() {
             <div className={'tab' + (tab === 'chepy' ? ' act' : '')} onClick={() => setTab('chepy')}>Cipher</div>
             <div className={'tab' + (tab === 'compare' ? ' act' : '')} onClick={() => setTab('compare')}>Compare</div>
             <div className={'tab' + (tab === 'sensitive' ? ' act' : '')} onClick={() => setTab('sensitive')}>Sensitive</div>
-            <div className={'tab' + (tab === 'bypass' ? ' act' : '')} onClick={() => { setTab('bypass'); bypass.loadRules(); bypass.loadPresets(); bypass.loadStatus(); }}>Bypass</div>
             <div className={'tab' + (tab === 'extensions' ? ' act' : '')} onClick={() => setTab('extensions')}>Extensions</div>
             <div className={'tab' + (tab === 'console' ? ' act' : '')} onClick={() => setTab('console')}>
               Console
@@ -2823,7 +2839,19 @@ function Blackwire() {
 
         {tab === 'intercept' && curPrj && React.createElement(InterceptPanel, __appCtx)}
 
-        {tab === 'scope' && curPrj && React.createElement(ScopePanel, __appCtx)}
+        {tab === 'scope' && curPrj && (
+          <div className="hist-wrap">
+            <div className="hist-sub-tabs">
+              <div className={'hist-sub-tab' + (scopeSubTab === 'scope' ? ' act' : '')} onClick={() => setScopeSubTab('scope')}>Scope</div>
+              <div className={'hist-sub-tab' + (scopeSubTab === 'bypass' ? ' act' : '')} onClick={() => { setScopeSubTab('bypass'); bypass.loadRules(); bypass.loadPresets(); bypass.loadStatus(); }}>Proxy Bypass</div>
+            </div>
+            <div style={{ flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
+              {scopeSubTab === 'scope'
+                ? React.createElement(ScopePanel, __appCtx)
+                : React.createElement(BypassManager, { toast: hookToast, bypass: bypass })}
+            </div>
+          </div>
+        )}
 
         {tab === 'repeater' && curPrj && React.createElement(RepeaterPanel, __appCtx)}
 
@@ -2837,8 +2865,6 @@ function Blackwire() {
         {tab === 'chepy' && curPrj && React.createElement(ChepyPanel, __appCtx)}
 
         {tab === 'sensitive' && curPrj && React.createElement(SensitivePanel, __appCtx)}
-
-        {tab === 'bypass' && curPrj && React.createElement(BypassManager, { toast: hookToast, bypass: bypass })}
 
         {tab === 'intruder' && curPrj && React.createElement(IntruderPanel, __appCtx)}
 

--- a/frontend/src/components/FilterBuilder.jsx
+++ b/frontend/src/components/FilterBuilder.jsx
@@ -1,0 +1,175 @@
+// FilterBuilder — constructor visual de filtros para principiantes.
+// Genera HTTPQL válido a partir de filas campo/operador/valor y lo escribe en
+// la barra de filtros (el usuario ve el HTTPQL real y aprende la sintaxis).
+
+const { useState, useRef, useEffect } = React;
+
+// Campos amigables → HTTPQL (namespace.field). type define operadores y formato.
+const FIELDS = [
+  { key: 'method', label: 'Método', ns: 'req', field: 'method', type: 'enum',
+    options: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] },
+  { key: 'code', label: 'Código de estado', ns: 'resp', field: 'code', type: 'number', placeholder: '404' },
+  { key: 'host', label: 'Host', ns: 'req', field: 'host', type: 'text', placeholder: 'example.com' },
+  { key: 'path', label: 'Ruta', ns: 'req', field: 'path', type: 'text', placeholder: '/api/login' },
+  { key: 'ext', label: 'Extensión', ns: 'req', field: 'ext', type: 'text', placeholder: 'js' },
+  { key: 'query', label: 'Query string', ns: 'req', field: 'query', type: 'text', placeholder: 'id=' },
+  { key: 'tls', label: 'HTTPS', ns: 'req', field: 'tls', type: 'bool' },
+  { key: 'reqlen', label: 'Tamaño request', ns: 'req', field: 'len', type: 'number', placeholder: '1000' },
+  { key: 'resplen', label: 'Tamaño response', ns: 'resp', field: 'len', type: 'number', placeholder: '10000' },
+];
+
+const TEXT_OPS = [
+  { op: 'cont', label: 'contiene' },
+  { op: 'ncont', label: 'no contiene' },
+  { op: 'eq', label: 'es igual a' },
+  { op: 'ne', label: 'no es' },
+  { op: 'regex', label: 'coincide (regex)' },
+];
+const NUM_OPS = [
+  { op: 'eq', label: '=' },
+  { op: 'ne', label: '≠' },
+  { op: 'gt', label: '>' },
+  { op: 'gte', label: '≥' },
+  { op: 'lt', label: '<' },
+  { op: 'lte', label: '≤' },
+];
+const ENUM_OPS = [
+  { op: 'eq', label: 'es' },
+  { op: 'ne', label: 'no es' },
+];
+const BOOL_OPS = [{ op: 'eq', label: 'es' }];
+
+function opsForField(f) {
+  if (f.type === 'number') return NUM_OPS;
+  if (f.type === 'enum') return ENUM_OPS;
+  if (f.type === 'bool') return BOOL_OPS;
+  return TEXT_OPS;
+}
+
+function defaultRow() {
+  return { id: Math.random().toString(36).slice(2), fieldKey: 'method', op: 'eq', value: 'GET' };
+}
+
+// Formatea una fila como cláusula HTTPQL. Devuelve '' si está incompleta.
+function rowToClause(row) {
+  const f = FIELDS.find(x => x.key === row.fieldKey);
+  if (!f) return '';
+  const head = `${f.ns}.${f.field}.${row.op}:`;
+  if (f.type === 'number') {
+    if (row.value === '' || isNaN(Number(row.value))) return '';
+    return head + String(Number(row.value));
+  }
+  if (f.type === 'bool') {
+    return head + (row.value === 'false' ? 'false' : 'true');
+  }
+  // text / enum → valor entre comillas (escapando comillas internas)
+  if (row.value === '' || row.value == null) return '';
+  return head + '"' + String(row.value).replace(/"/g, '\\"') + '"';
+}
+
+function buildQuery(rows, combinator) {
+  const clauses = rows.map(rowToClause).filter(Boolean);
+  return clauses.join(combinator === 'OR' ? ' OR ' : ' AND ');
+}
+
+export function FilterBuilder({ setSearch }) {
+  const [open, setOpen] = useState(false);
+  const [rows, setRows] = useState([defaultRow()]);
+  const [combinator, setCombinator] = useState('AND');
+  const wrapRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDown = (e) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
+  const preview = buildQuery(rows, combinator);
+
+  const updateRow = (id, patch) => setRows(rs => rs.map(r => {
+    if (r.id !== id) return r;
+    const next = { ...r, ...patch };
+    // Al cambiar de campo, ajustar operador y valor por defecto según el tipo.
+    if (patch.fieldKey) {
+      const f = FIELDS.find(x => x.key === patch.fieldKey);
+      const ops = opsForField(f);
+      next.op = ops[0].op;
+      if (f.type === 'enum') next.value = f.options[0];
+      else if (f.type === 'bool') next.value = 'true';
+      else next.value = '';
+    }
+    return next;
+  }));
+
+  const addRow = () => setRows(rs => [...rs, defaultRow()]);
+  const removeRow = (id) => setRows(rs => (rs.length <= 1 ? rs : rs.filter(r => r.id !== id)));
+
+  const apply = () => {
+    if (preview) setSearch(preview);
+    setOpen(false);
+  };
+
+  return (
+    <div className="flt-builder-wrap" ref={wrapRef}>
+      <div className={'flt-tog' + (open ? ' act' : '')} onClick={() => setOpen(o => !o)} title="Constructor de filtros">🔧</div>
+      {open && (
+        <div className="flt-builder-dd">
+          <div className="flt-builder-hd">
+            <span>Constructor de filtros</span>
+            <select className="sel" value={combinator} onChange={e => setCombinator(e.target.value)}>
+              <option value="AND">Coincidir con TODAS</option>
+              <option value="OR">Coincidir con CUALQUIERA</option>
+            </select>
+          </div>
+
+          {rows.map(row => {
+            const f = FIELDS.find(x => x.key === row.fieldKey);
+            const ops = opsForField(f);
+            return (
+              <div key={row.id} className="flt-builder-row">
+                <select className="sel" value={row.fieldKey} onChange={e => updateRow(row.id, { fieldKey: e.target.value })}>
+                  {FIELDS.map(x => <option key={x.key} value={x.key}>{x.label}</option>)}
+                </select>
+                <select className="sel" value={row.op} onChange={e => updateRow(row.id, { op: e.target.value })}>
+                  {ops.map(o => <option key={o.op} value={o.op}>{o.label}</option>)}
+                </select>
+                {f.type === 'enum' ? (
+                  <select className="sel" value={row.value} onChange={e => updateRow(row.id, { value: e.target.value })}>
+                    {f.options.map(o => <option key={o} value={o}>{o}</option>)}
+                  </select>
+                ) : f.type === 'bool' ? (
+                  <select className="sel" value={row.value} onChange={e => updateRow(row.id, { value: e.target.value })}>
+                    <option value="true">sí</option>
+                    <option value="false">no</option>
+                  </select>
+                ) : (
+                  <input className="inp" value={row.value}
+                    type={f.type === 'number' ? 'number' : 'text'}
+                    placeholder={f.placeholder || ''}
+                    onChange={e => updateRow(row.id, { value: e.target.value })} />
+                )}
+                <button className="btn btn-sm btn-d flt-builder-del" onClick={() => removeRow(row.id)}
+                  disabled={rows.length <= 1} title="Quitar condición">×</button>
+              </div>
+            );
+          })}
+
+          <button className="btn btn-sm btn-s flt-builder-add" onClick={addRow}>+ Agregar condición</button>
+
+          <div className="flt-builder-preview">
+            <span className="flt-builder-preview-lbl">Filtro generado</span>
+            <code>{preview || '(vacío)'}</code>
+          </div>
+
+          <div className="flt-builder-acts">
+            <button className="btn btn-sm btn-s" onClick={() => { setRows([defaultRow()]); setCombinator('AND'); }}>Reiniciar</button>
+            <button className="btn btn-sm btn-p" onClick={apply} disabled={!preview}>Aplicar filtro</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/tabs/CollectionsPanel.jsx
+++ b/frontend/src/components/tabs/CollectionsPanel.jsx
@@ -28,7 +28,8 @@ export function CollectionsPanel(props) {
                 ))}
                 {colls.length === 0 && (
                   <div className="empty" style={{ padding: 20, fontSize: 11 }}>
-                    <span>No collections yet</span>
+                    <span>Aún no hay colecciones</span>
+                    <span className="empty-hint">Una colección encadena varias peticiones (p. ej. login → acción) y pasa variables entre ellas. Créala con el botón de arriba.</span>
                   </div>
                 )}
               </div>
@@ -57,12 +58,13 @@ export function CollectionsPanel(props) {
                 ))}
                 {selColl && collItems.length === 0 && (
                   <div className="empty" style={{ padding: 20, fontSize: 11 }}>
-                    <span>Add requests via right-click in History</span>
+                    <span>Colección vacía</span>
+                    <span className="empty-hint">Agrega peticiones con clic derecho → "Add to Collection" en History.</span>
                   </div>
                 )}
                 {!selColl && (
                   <div className="empty" style={{ padding: 20, fontSize: 11 }}>
-                    <span>Select a collection</span>
+                    <span>Selecciona una colección para ver sus pasos</span>
                   </div>
                 )}
                 {Object.keys(collVars).length > 0 && (

--- a/frontend/src/components/tabs/ComparePanel.jsx
+++ b/frontend/src/components/tabs/ComparePanel.jsx
@@ -17,7 +17,8 @@ export function ComparePanel(props) {
             {!cmpA && !cmpB ? (
               <div className="empty">
                 <div className="empty-i">&#8596;</div>
-                <span>Right-click a request and choose "Send to Compare (A/B)"</span>
+                <span>Compara dos peticiones lado a lado</span>
+                <span className="empty-hint">En History o Site Map, haz clic derecho en una petición y elige <b>Send to Compare (A)</b> y luego otra como <b>(B)</b>. Aquí verás el diff resaltado.</span>
               </div>
             ) : (
               <div className="cmp-wrap" ref={wrapRef}>

--- a/frontend/src/components/tabs/HistoryPanel.jsx
+++ b/frontend/src/components/tabs/HistoryPanel.jsx
@@ -1,6 +1,8 @@
 // HistoryPanel — extraído de App.jsx (pestaña 'history').
 // Recibe todo el estado/handlers vía props (objeto __appCtx de App.jsx).
 
+import { FilterBuilder } from '../FilterBuilder.jsx';
+
 const BUILTIN_FILTER_PRESETS = [
   { name: 'Errors (4xx/5xx)', query: 'resp.code.gte:400' },
   { name: 'Server errors (5xx)', query: 'resp.code.gte:500' },
@@ -56,6 +58,7 @@ export function HistoryPanel(props) {
                         </div>
                       )}
                     </div>
+                    <FilterBuilder setSearch={setSearch} />
                     <div className={'flt-tog' + (scopeOnly ? ' act' : '')} onClick={() => setScopeOnly(!scopeOnly)}>Scope</div>
                     <div className={'flt-tog' + (savedOnly ? ' act' : '')} onClick={() => setSavedOnly(!savedOnly)}>★</div>
                   </div>
@@ -100,8 +103,18 @@ export function HistoryPanel(props) {
                       ))}
                       {filtered.length === 0 && (
                         <div className="empty">
-                          <div className="empty-i">□</div>
-                          <span>No requests</span>
+                          <div className="empty-i">🌐</div>
+                          {(search || scopeOnly || savedOnly) ? (
+                            <React.Fragment>
+                              <span>Ningún request coincide con el filtro</span>
+                              <span className="empty-hint">Ajusta o limpia el filtro para ver más resultados.</span>
+                            </React.Fragment>
+                          ) : (
+                            <React.Fragment>
+                              <span>Aún no hay tráfico capturado</span>
+                              <span className="empty-hint">Inicia el proxy con <b>▶ Start</b> (arriba a la derecha) y navega en tu navegador configurado para ver las peticiones aquí.</span>
+                            </React.Fragment>
+                          )}
                         </div>
                       )}
                     </div>
@@ -208,7 +221,9 @@ export function HistoryPanel(props) {
                     </React.Fragment>
                   ) : (
                     <div className="empty">
-                      <span>Select request</span>
+                      <div className="empty-i">👈</div>
+                      <span>Selecciona una petición</span>
+                      <span className="empty-hint">Haz clic en cualquier request de la lista para ver su detalle (headers, body, respuesta).</span>
                     </div>
                   )}
                 </div>
@@ -235,7 +250,9 @@ export function HistoryPanel(props) {
                     ))}
                     {wsConns.length === 0 && (
                       <div className="empty" style={{ padding: 30 }}>
-                        <span>No WebSocket connections captured</span>
+                        <div className="empty-i">🔌</div>
+                        <span>Sin conexiones WebSocket</span>
+                        <span className="empty-hint">Con el proxy activo, navega a un sitio que use WebSockets y las conexiones aparecerán aquí.</span>
                       </div>
                     )}
                   </div>
@@ -258,10 +275,10 @@ export function HistoryPanel(props) {
                       </div>
                     ))}
                     {selWsConn && wsFrames.length === 0 && (
-                      <div className="empty" style={{ padding: 30 }}><span>No frames</span></div>
+                      <div className="empty" style={{ padding: 30 }}><span>Esta conexión aún no tiene frames</span></div>
                     )}
                     {!selWsConn && (
-                      <div className="empty" style={{ padding: 30 }}><span>Select a connection</span></div>
+                      <div className="empty" style={{ padding: 30 }}><span>Selecciona una conexión para ver sus frames</span></div>
                     )}
                   </div>
                 </div>
@@ -294,7 +311,7 @@ export function HistoryPanel(props) {
                       )}
                     </React.Fragment>
                   ) : (
-                    <div className="empty"><span>Select a frame</span></div>
+                    <div className="empty"><span>Selecciona un frame para ver su contenido</span></div>
                   )}
                 </div>
               </div>
@@ -343,8 +360,9 @@ export function HistoryPanel(props) {
                   <div className="pnl-cnt">
                     {Object.keys(siteTree).length === 0 ? (
                       <div className="empty">
-                        <div className="empty-i">🌐</div>
-                        <span>No requests captured</span>
+                        <div className="empty-i">🗺️</div>
+                        <span>Aún no hay mapa del sitio</span>
+                        <span className="empty-hint">Navega con el proxy activo: BlackWire irá construyendo aquí el árbol de hosts y rutas visitadas.</span>
                       </div>
                     ) : (
                       Object.entries(siteTree)
@@ -411,7 +429,11 @@ export function HistoryPanel(props) {
                           ))}
                         </div>
                       ) : (
-                        <div className="empty"><span>Click a node in the tree</span></div>
+                        <div className="empty">
+                          <div className="empty-i">👈</div>
+                          <span>Selecciona un nodo del árbol</span>
+                          <span className="empty-hint">Haz clic en un host o ruta a la izquierda para ver sus peticiones.</span>
+                        </div>
                       )}
                     </div>
                   </div>

--- a/frontend/src/components/tabs/InterceptPanel.jsx
+++ b/frontend/src/components/tabs/InterceptPanel.jsx
@@ -62,7 +62,7 @@ export function InterceptPanel(props) {
                     <div className="icept-empty" style={{ padding: '40px 16px' }}>
                       <span style={{ fontSize: 28 }}>{intOn ? '⏳' : '🔓'}</span>
                       <span style={{ fontSize: 11, textAlign: 'center', lineHeight: 1.5 }}>
-                        {intOn ? 'Waiting for traffic...' : 'Enable intercept to capture requests'}
+                        {intOn ? 'Esperando tráfico… navega para que las peticiones se pausen aquí y puedas editarlas antes de reenviarlas.' : 'Activa la interceptación para pausar y editar cada petición antes de que salga.'}
                       </span>
                     </div>
                   )}

--- a/frontend/src/components/tabs/RepeaterPanel.jsx
+++ b/frontend/src/components/tabs/RepeaterPanel.jsx
@@ -191,7 +191,11 @@ export function RepeaterPanel(props) {
                       </div>
                     </div>
                   ) : (
-                    <div className="code">Send a request</div>
+                    <div className="empty">
+                      <div className="empty-i">📤</div>
+                      <span>Aún no hay respuesta</span>
+                      <span className="empty-hint">Edita método, URL, headers o body a la izquierda y pulsa <b>▶ Send</b> (o Ctrl+Enter) para enviar la petición y ver la respuesta aquí.</span>
+                    </div>
                   )}
                 </div>
               </div>

--- a/frontend/src/components/tabs/ScopePanel.jsx
+++ b/frontend/src/components/tabs/ScopePanel.jsx
@@ -30,7 +30,9 @@ export function ScopePanel(props) {
               ))}
               {scopeRules.length === 0 && (
                 <div className="empty" style={{ padding: 30 }}>
-                  <span>No rules - all in scope</span>
+                  <div className="empty-i">🎯</div>
+                  <span>Sin reglas — todo el tráfico está en scope</span>
+                  <span className="empty-hint">El "scope" define qué sitios te interesan. Agrega una regla <b>Include</b> (p. ej. <code>*.example.com</code>) para enfocarte solo en ese objetivo, o <b>Exclude</b> para ignorar ruido. Sin reglas, se captura todo.</span>
                 </div>
               )}
             </div>

--- a/frontend/src/components/tabs/SensitivePanel.jsx
+++ b/frontend/src/components/tabs/SensitivePanel.jsx
@@ -68,7 +68,17 @@ export function SensitivePanel(props) {
                   {sensFiltered.length === 0 && !sensScanning && (
                     <div className="empty" style={{ padding: '40px 0' }}>
                       <div className="empty-i">{sensResults.length === 0 ? '\uD83D\uDD0D' : '\uD83D\uDD0E'}</div>
-                      <span>{sensResults.length === 0 ? 'Click Scan to analyze captured traffic' : 'No results match your filter'}</span>
+                      {sensResults.length === 0 ? (
+                        <React.Fragment>
+                          <span>Busca datos sensibles en el tráfico capturado</span>
+                          <span className="empty-hint">Escanea el historial en busca de tokens, claves de API, credenciales y datos personales. Todo el análisis es local.</span>
+                          <button className="btn btn-sm btn-g" style={{ marginTop: '10px' }} onClick={runSensitiveScan} disabled={reqs.length === 0}>
+                            {reqs.length === 0 ? 'Captura tráfico primero' : 'Escanear ahora'}
+                          </button>
+                        </React.Fragment>
+                      ) : (
+                        <span>Ningún resultado coincide con el filtro</span>
+                      )}
                     </div>
                   )}
                   {sensFiltered.map((r, i) => (

--- a/packaging/src-tauri/Cargo.toml
+++ b/packaging/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackwire-desktop"
-version = "1.0.0"
+version = "1.0.1"
 description = "Blackwire - HTTP(S) Intercepting Proxy"
 authors = ["Blackwire Team"]
 license = "MIT"

--- a/packaging/src-tauri/tauri.conf.json
+++ b/packaging/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Blackwire",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "com.blackwire.app",
   "build": {
     "beforeDevCommand": "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "blackwire"
-version = "1.0.0"
+version = "1.0.1"
 description = "Proxy interceptor HTTP/HTTPS para pruebas de seguridad — alternativa ligera y extensible a Burp Suite/OWASP ZAP."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Mejoras de usabilidad enfocadas en hacer BlackWire más amigable para principiantes, más el bump a **1.0.1 "Asahi"**.

## Constructor visual de filtros
Nuevo `FilterBuilder.jsx` en History: filas campo/operador/valor con etiquetas en lenguaje claro, combinador **Coincidir con TODAS/CUALQUIERA** (AND/OR), vista previa en vivo del HTTPQL generado y botón para aplicarlo a la barra de filtros (el usuario ve el HTTPQL real y aprende la sintaxis). Botón 🔧 junto al dropdown de presets.

## Estados vacíos que enseñan
Reescritos los estados vacíos de cara al principiante (History, Site Map, Scope, Sensitive, Collections, Compare, WebSocket, Interceptor, Repeater) con copy claro en español que explica qué hacer; botón "Escanear ahora" en el estado vacío de Sensitive. Corrección de acentos que se habían escrito como secuencias `\u00XX` literales en texto JSX.

## Proxy Bypass dentro de Scope
El Proxy Bypass deja de ser una pestaña de nivel superior y pasa a ser una **sub-pestaña dentro de Scope** (Scope / Proxy Bypass). La funcionalidad no cambia.

## Release
- Bump de versión a `1.0.1` en `pyproject.toml`, `Cargo.toml` y `tauri.conf.json`.
- Codename: **Asahi**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)